### PR TITLE
 Remove actionlistener on buttons when the end is reached & progressive Lazyload support added

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1848,7 +1848,7 @@
 
         } else {
 
-	          _.updateArrows()
+            _.updateArrows()
             _.$slider.trigger('allImagesLoaded', [ _ ]);
 
         }
@@ -2991,7 +2991,7 @@
                 var sliderOffsetRight = ($(window).width() - (_.$slider.offset().left + _.$slider.outerWidth()));
                 var lastSlideOffsetSlider = lastSlideOffsetRight - sliderOffsetRight;
 
-	              if (lastSlideOffsetSlider > -1) {
+                if (lastSlideOffsetSlider > -1) {
                     _.$nextArrow.addClass('slick-disabled').attr('aria-disabled', 'true')
                     _.touchObject.edgeHit = true
                     if (_.options.arrows === true && _.slideCount > _.options.slidesToShow) {
@@ -3001,10 +3001,10 @@
                             _.$nextArrow && _.$nextArrow.off('keydown.slick', _.keyHandler)
                         }
                     }
-	              }
-	              else {
-		                _.$nextArrow.removeClass('slick-disabled').attr('aria-disabled', 'false')
-		                if (_.options.arrows === true && _.slideCount > _.options.slidesToShow) {
+                }
+                else {
+                    _.$nextArrow.removeClass('slick-disabled').attr('aria-disabled', 'false')
+                    if (_.options.arrows === true && _.slideCount > _.options.slidesToShow) {
                         _.$nextArrow
                         .off('click.slick')
                         .on('click.slick', {
@@ -3014,8 +3014,8 @@
                         if (_.options.accessibility === true) {
                             _.$nextArrow.on('keydown.slick', _.keyHandler)
                         }
-		                }
-	              }
+                    }
+                }
             }
         }
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1848,6 +1848,7 @@
 
         } else {
 
+	          _.updateArrows()
             _.$slider.trigger('allImagesLoaded', [ _ ]);
 
         }
@@ -2989,13 +2990,32 @@
                 var lastSlideOffsetRight = ($(window).width() - (lastSlide.offset().left + lastSlide.outerWidth()));
                 var sliderOffsetRight = ($(window).width() - (_.$slider.offset().left + _.$slider.outerWidth()));
                 var lastSlideOffsetSlider = lastSlideOffsetRight - sliderOffsetRight;
-    
-                if(lastSlideOffsetSlider > -1) {
-                    _.$nextArrow.addClass('slick-disabled').attr('aria-disabled', 'true');
-                }
-                else {
-                    _.$nextArrow.removeClass('slick-disabled').attr('aria-disabled', 'true');
-                }
+
+	              if (lastSlideOffsetSlider > -1) {
+                    _.$nextArrow.addClass('slick-disabled').attr('aria-disabled', 'true')
+                    _.touchObject.edgeHit = true
+                    if (_.options.arrows === true && _.slideCount > _.options.slidesToShow) {
+                        _.$nextArrow && _.$nextArrow.off('click.slick', _.changeSlide)
+
+                        if (_.options.accessibility === true) {
+                            _.$nextArrow && _.$nextArrow.off('keydown.slick', _.keyHandler)
+                        }
+                    }
+	              }
+	              else {
+		                _.$nextArrow.removeClass('slick-disabled').attr('aria-disabled', 'false')
+		                if (_.options.arrows === true && _.slideCount > _.options.slidesToShow) {
+                        _.$nextArrow
+                        .off('click.slick')
+                        .on('click.slick', {
+                            message: 'next'
+                        }, _.changeSlide)
+
+                        if (_.options.accessibility === true) {
+                            _.$nextArrow.on('keydown.slick', _.keyHandler)
+                        }
+		                }
+	              }
             }
         }
 


### PR DESCRIPTION
Hey Ricardo,
I liked your solution. For me there were some bugs I solved.
There is still a bug when you drag the slider over the edge and you use the arrows to the left after that you need multiple clicks, because the active is further back. So if you have time maybe you can solve it :) would appreciate it. 👍 